### PR TITLE
Add margin to brand-logo-img to adapt on sm and xl

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<body>
 		<header>
 			<nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
-				<div class="container-fluid">
+				<div class="container-fluid mx-2 mx-xl-4">
 				<a class="navbar-brand" href="#">
 					<img src="./images/profile-img.WEBP" alt="Jen Patchett Logo Image" class="d-inline-block brand-logo-img">
       				Jen Patchett

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,8 @@
 	height: 50px;
 	border: 1px solid #7843E9;
 	border-radius: 50%;
-	background-color: #7843E9;;
+	background-color: #7843E9;
+	margin-right: 10px;
 }
 
 #site-title {


### PR DESCRIPTION
- html: added `mx-2 mx-xl-4` to `brand-logo-img` wrapper to add margin left and right (mx) with varying responsive margin size for small and xl screen sizes. 

- styles: added `margin-right` to `brand-logo-img` to apply 10px space between img and name in header.