### PR TITLE
PP-1 Add padding-right to Skills accordion body

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -103,8 +103,9 @@ section {
 	font-weight: 500;
 }
 
-.accordion-body {
+.accordion-body p {
 	margin-left: 10px;
+	padding-right: 5px;
 }
 
 fieldset {


### PR DESCRIPTION
Skills BS accordion appeared to have padding-left but not right, so text in the accordion-body was pushed up to the border.

- Added 5px padding-right to appear equal on L and R sides. 